### PR TITLE
Add --override-module-licence and --check-go-modules options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
   - 1.11.x
+  - 1.12.x
 
 script: make travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 1.1.0
+- [Add --override-module-licence option](https://github.com/sky-uk/licence-compliance-checker/pull/19)
+
 ## 1.0.0
 - [Use go-license-detector upstream repo rather than fork](https://github.com/sky-uk/licence-compliance-checker/pull/16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## 1.1.0
-- [Add --override-module-licence option](https://github.com/sky-uk/licence-compliance-checker/pull/19)
+- [Add --override-module-licence and --check-go-modules options](https://github.com/sky-uk/licence-compliance-checker/pull/19)
 
 ## 1.0.0
 - [Use go-license-detector upstream repo rather than fork](https://github.com/sky-uk/licence-compliance-checker/pull/16)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ setup :
 	go get -v golang.org/x/lint/golint golang.org/x/tools/cmd/goimports github.com/golang/dep/cmd/dep
 	go get -v github.com/onsi/ginkgo/ginkgo && cd $$GOPATH/src/github.com/onsi/ginkgo && git checkout 'v1.6.0' && go install github.com/onsi/ginkgo/ginkgo
 	dep ensure -v -vendor-only
-	cd test/e2e/testdata/go-module && GO111MODULE=on go build
 
 build: ensure-build-dir-exists
 	@echo "== build"
@@ -29,7 +28,7 @@ licencecheck:
 	set -e ;\
  	restricted=$$(paste -s -d ',' restricted-licences.txt) ;\
  	projects=$$(dep status -f='vendor/{{ .ProjectRoot }} ') ;\
- 	$(BUILD_DIR)/bin/licence-compliance-checker -L error -A -r $$restricted -m github.com/spf13/cobra=MIT $$projects ;
+ 	$(BUILD_DIR)/bin/licence-compliance-checker -L error -A -r $$restricted $$projects ;
 
 vet:
 	@echo "== vet"
@@ -47,7 +46,10 @@ ensure-build-dir-exists:
 ensure-test-report-dir-exists: ensure-build-dir-exists
 	mkdir -p $(junit_report_dir)
 
-test: ensure-test-report-dir-exists
+ensure-go-modules:
+	cd $(PROJECT_DIR)/test/e2e/testdata/go-module && GO111MODULE=on go mod download
+
+test: ensure-test-report-dir-exists ensure-go-modules
 	@echo "== test"
 	ginkgo -r --v --progress . pkg test/e2e -- -junit-report-dir $(junit_report_dir)
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ setup :
 	go get -v golang.org/x/lint/golint golang.org/x/tools/cmd/goimports github.com/golang/dep/cmd/dep
 	go get -v github.com/onsi/ginkgo/ginkgo && cd $$GOPATH/src/github.com/onsi/ginkgo && git checkout 'v1.6.0' && go install github.com/onsi/ginkgo/ginkgo
 	dep ensure -v -vendor-only
+	cd test/e2e/testdata/go-module && GO111MODULE=on go build
 
 build: ensure-build-dir-exists
 	@echo "== build"
@@ -28,7 +29,7 @@ licencecheck:
 	set -e ;\
  	restricted=$$(paste -s -d ',' restricted-licences.txt) ;\
  	projects=$$(dep status -f='vendor/{{ .ProjectRoot }} ') ;\
- 	$(BUILD_DIR)/bin/licence-compliance-checker -L error -A -r $$restricted $$projects ;
+ 	$(BUILD_DIR)/bin/licence-compliance-checker -L error -A -r $$restricted -m github.com/spf13/cobra=MIT $$projects ;
 
 vet:
 	@echo "== vet"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,17 @@ go get github.com/sky-uk/licence-compliance-checker
 
 ## Usage
 
+With packages in a vendor directory:
+
 ```
 licence-compliance-checker -r LGPL -r GPL -r AGPL -o vendor/github.com/spf13/cobra=MIT vendor/github.com/spf13/cobra vendor/golang.org/x/crypto
+```
+
+With Go module installed packages (must be run outside of `$GOPATH`, or with
+`GO111MODULE=on`):
+
+```
+licence-compliance-checker -r LGPL -r GPL -r AGPL -m github.com/spf13/cobra=MIT $GOPATH/pkg/mod/github.com/spf13/cobra@v0.0.3/
 ```
 
 See the `licencecheck` target in the [Makefile](Makefile) for an example of how to use with dependencies managed by `go dep`
@@ -35,7 +44,8 @@ Input argument | Meaning
 ---------|---------
 --restricted-licence (-r) | The name of the licence to restrict. Repeat this flag to specify multiple values.
 --ignore-project (-i) | Project which licence will not be checked for compliance. Repeat this flag to specify multiple values.
---override-licence (-o) | Can be used to override the licence detected for a project - e.g. github.com/spf13/cobra=MIT. Repeat this flag to specify multiple values.
+--override-licence (-o) | Can be used to override the licence detected for a project directory - e.g. vendor/github.com/spf13/cobra=MIT. Repeat this flag to specify multiple values.
+--override-module-licence (-m) | Can be used to override the licence detected for a go module - e.g. github.com/spf13/cobra=MIT. Repeat this flag to specify multiple values.
 
 Output argument | Meaning 
 ---------|---------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With Go module installed packages (must be run outside of `$GOPATH`, or with
 `GO111MODULE=on`):
 
 ```
-licence-compliance-checker -r LGPL -r GPL -r AGPL -m github.com/spf13/cobra=MIT $GOPATH/pkg/mod/github.com/spf13/cobra@v0.0.3/
+licence-compliance-checker -r LGPL -r GPL -r AGPL -m github.com/spf13/cobra=MIT --check-go-modules
 ```
 
 See the `licencecheck` target in the [Makefile](Makefile) for an example of how to use with dependencies managed by `go dep`
@@ -46,6 +46,7 @@ Input argument | Meaning
 --ignore-project (-i) | Project which licence will not be checked for compliance. Repeat this flag to specify multiple values.
 --override-licence (-o) | Can be used to override the licence detected for a project directory - e.g. vendor/github.com/spf13/cobra=MIT. Repeat this flag to specify multiple values.
 --override-module-licence (-m) | Can be used to override the licence detected for a go module - e.g. github.com/spf13/cobra=MIT. Repeat this flag to specify multiple values.
+--check-go-modules | Check all go modules a project depends on. This replaces specifying multiple project directories as positional arguments.
 
 Output argument | Meaning 
 ---------|---------

--- a/main.go
+++ b/main.go
@@ -51,6 +51,10 @@ func init() {
 func validateCompliance(_ *cobra.Command, args []string) {
 	setLogLevel(logLevel)
 
+	if len(overriddenModuleLicences) > 0 && len(overriddenLicences) > 0 {
+		logAndExit("Only use one of --override-module-licence (%d uses) and --override-licence (%d uses)", len(overriddenModuleLicences), len(overriddenLicences))
+	}
+
 	for module, licence := range overriddenModuleLicences {
 		cmd := exec.Command("go", "list", "-m", "-f", "\"{{.Dir}}\"", module)
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func validateCompliance(_ *cobra.Command, args []string) {
 	for module, licence := range overriddenModuleLicences {
 		cmd := exec.Command("go", "list", "-m", "-f", "\"{{.Dir}}\"", module)
 
-		out, err := cmd.CombinedOutput()
+		out, err := cmd.Output()
 		if err != nil {
 			logAndExit("Failed to list go module %s: output: %s, error: %s", module, out, err)
 		}
@@ -108,7 +108,7 @@ func validateCompliance(_ *cobra.Command, args []string) {
 
 func getGoModules() ([]string, error) {
 	cmd := exec.Command("go", "list", "-m", "-f", "\"{{.Dir}}\"", "all")
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "L", "", "(output) should be one of: (none), debug, info, warn, error, fatal, panic. default (none)")
 	rootCmd.PersistentFlags().BoolVarP(&showComplianceAll, "show-compliance-all", "A", false, "(output) to show compliance checks as JSON regardless of outcome")
 	rootCmd.PersistentFlags().BoolVarP(&showComplianceErrors, "show-compliance-errors", "E", false, "(output) to show compliance checks as JSON only in case of errors")
-	rootCmd.PersistentFlags().BoolVarP(&checkGoModules, "check-go-modules", "", false, "check all go modules a project depends on")
+	rootCmd.PersistentFlags().BoolVarP(&checkGoModules, "check-go-modules", "", false, "check all go modules a project depends on. This replaces specifying multiple project directories as positional arguments.")
 	rootCmd.MarkPersistentFlagRequired("restricted-licence")
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -166,7 +166,7 @@ var _ = Describe("License Compliance Checker", func() {
 			Expect(err).To(HaveOccurred())
 
 			results := resultsFromJSON(string(output))
-			Expect(results.Restricted).To(HaveLen(2))
+			Expect(results.Restricted).To(HaveLen(5))
 			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/crypto"))
 		})
 
@@ -194,8 +194,9 @@ var _ = Describe("License Compliance Checker", func() {
 			Expect(err).To(HaveOccurred())
 
 			results := resultsFromJSON(string(output))
-			Expect(results.Restricted).To(HaveLen(1))
-			Expect(results.Restricted[0].Project).To(ContainSubstring("github.com/sky-uk/licence-compliance-checker"))
+			Expect(results.Restricted).To(HaveLen(4))
+			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/net"))
+			Expect(results.Restricted[3].Project).To(ContainSubstring("github.com/sky-uk/licence-compliance-checker"))
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -166,7 +166,7 @@ var _ = Describe("License Compliance Checker", func() {
 			Expect(err).To(HaveOccurred())
 
 			results := resultsFromJSON(string(output))
-			Expect(results.Restricted).To(HaveLen(3))
+			Expect(results.Restricted).To(HaveLen(2))
 			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/crypto"))
 		})
 
@@ -194,9 +194,8 @@ var _ = Describe("License Compliance Checker", func() {
 			Expect(err).To(HaveOccurred())
 
 			results := resultsFromJSON(string(output))
-			Expect(results.Restricted).To(HaveLen(2))
-			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/text"))
-			Expect(results.Restricted[1].Project).To(ContainSubstring("github.com/sky-uk/licence-compliance-checker"))
+			Expect(results.Restricted).To(HaveLen(1))
+			Expect(results.Restricted[0].Project).To(ContainSubstring("github.com/sky-uk/licence-compliance-checker"))
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -8,16 +8,32 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/licence-compliance-checker/pkg/compliance"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
-const commandPath = "../../build/bin/licence-compliance-checker"
+var commandPath string
+var testModulePath string
 
 var junitReportDir string
 
 func init() {
 	flag.StringVar(&junitReportDir, "junit-report-dir", ".", "path to the directory that will contain the test reports")
+
+	var err error
+	commandPath, err = filepath.Abs("../../build/bin/licence-compliance-checker")
+	if err != nil {
+		fmt.Printf("Can't expand path to licence-compliance-checker binary: %s\n", err)
+		os.Exit(1)
+	}
+
+	testModulePath, err = filepath.Abs("./testdata/go-module")
+	if err != nil {
+		fmt.Printf("Can't expand path to test module: %s\n", err)
+		os.Exit(1)
+	}
 }
 
 func TestE2E(t *testing.T) {
@@ -124,6 +140,63 @@ var _ = Describe("License Compliance Checker", func() {
 			output, err := exec.Command(commandPath, "-A", "-r", "BSD", "testdata/MIT").CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(Not(Equal("")))
+		})
+	})
+
+	Context("modules", func() {
+		It("should check a project's modules", func() {
+			cmd := exec.Command(commandPath, "-r", "BSD", "--check-go-modules")
+			cmd.Dir = testModulePath
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "GO111MODULE=on")
+
+			output, err := cmd.CombinedOutput()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(Equal(""))
+		})
+
+		It("should fail for a non-compliant module", func() {
+			cmd := exec.Command(commandPath, "-A", "-r", "BSD-3-Clause", "--check-go-modules")
+			cmd.Dir = testModulePath
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "GO111MODULE=on")
+
+			output, err := cmd.CombinedOutput()
+			Expect(err).To(HaveOccurred())
+
+			results := resultsFromJSON(string(output))
+			Expect(results.Restricted).To(HaveLen(3))
+			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/crypto"))
+		})
+
+		It("should fail with an overridden non-compliant module", func() {
+			cmd := exec.Command(commandPath, "-A", "-r", "MIT", "-m", "golang.org/x/crypto=MIT", "--check-go-modules")
+			cmd.Dir = testModulePath
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "GO111MODULE=on")
+
+			output, err := cmd.CombinedOutput()
+			Expect(err).To(HaveOccurred())
+
+			results := resultsFromJSON(string(output))
+			Expect(results.Restricted).To(HaveLen(1))
+			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/crypto"))
+		})
+
+		It("should succeed with an overridden compliant module", func() {
+			cmd := exec.Command(commandPath, "-A", "-r", "BSD-3-Clause", "-m", "golang.org/x/crypto=MIT", "--check-go-modules")
+			cmd.Dir = testModulePath
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "GO111MODULE=on")
+
+			output, err := cmd.CombinedOutput()
+			Expect(err).To(HaveOccurred())
+
+			results := resultsFromJSON(string(output))
+			Expect(results.Restricted).To(HaveLen(2))
+			Expect(results.Restricted[0].Project).To(ContainSubstring("golang.org/x/text"))
+			Expect(results.Restricted[1].Project).To(ContainSubstring("github.com/sky-uk/licence-compliance-checker"))
 		})
 	})
 

--- a/test/e2e/testdata/go-module/LICENSE
+++ b/test/e2e/testdata/go-module/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Sky UK Ltd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/e2e/testdata/go-module/go.mod
+++ b/test/e2e/testdata/go-module/go.mod
@@ -1,5 +1,3 @@
 module github.com/sky-uk/licence-compliance-checker/e2e/testdata/go-module
 
-go 1.12
-
 require golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529

--- a/test/e2e/testdata/go-module/go.mod
+++ b/test/e2e/testdata/go-module/go.mod
@@ -1,0 +1,5 @@
+module github.com/sky-uk/licence-compliance-checker/e2e/testdata/go-module
+
+go 1.12
+
+require golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529

--- a/test/e2e/testdata/go-module/go.sum
+++ b/test/e2e/testdata/go-module/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 h1:iMGN4xG0cnqj3t+zOM8wUB0BiPKHEwSxEZCvzcbZuvk=
+golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/test/e2e/testdata/go-module/main.go
+++ b/test/e2e/testdata/go-module/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"golang.org/x/crypto/acme"
+)
+
+func main() {
+	fmt.Println(acme.LetsEncryptURL)
+}


### PR DESCRIPTION
This allows you to override the licence for a given go module. This
finds the directory for the module, then continues with compliance
checking normally.