### PR TITLE
Order licence with same confidence level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,11 @@ go:
   - 1.12.x
 
 script: make travis
+
+# This applies to `push` types only, not pull request
+# Travis will trigger `push` builds on master or tag to avoid building branches twice for pull requests - see https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests
+# The tag to build should follow semantic versioning
+branches:
+  only:
+    - master
+    - /^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 1.1.1
+- [BUGFIX] [Ordering of licences with same confidence level is non-deterministic](https://github.com/sky-uk/licence-compliance-checker/pull/21)
+
 ## 1.1.0
 - [Add --override-module-licence and --check-go-modules options](https://github.com/sky-uk/licence-compliance-checker/pull/19)
 

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -45,6 +45,8 @@ func (c *Compliance) Validate(projectPaths []string) (*Results, error) {
 	})
 
 	for _, detectionResult := range detectionResults {
+		c.sortMatchesByConfidenceThenLicence(detectionResult.Matches)
+
 		if c.projectIgnored(detectionResult) {
 			complianceResults.Ignored = append(complianceResults.Ignored, detectionResult)
 			continue
@@ -72,10 +74,6 @@ func (c *Compliance) Validate(projectPaths []string) (*Results, error) {
 }
 
 func (c *Compliance) restrictedLicence(detectionResult detection.Result) bool {
-	sort.Slice(detectionResult.Matches, func(i, j int) bool {
-		return detectionResult.Matches[i].Confidence > detectionResult.Matches[j].Confidence
-	})
-
 	mostProbableLicence := detectionResult.Matches[0].Licence
 	for _, restrictedLicence := range c.config.RestrictedLicences {
 		if mostProbableLicence == restrictedLicence {
@@ -93,4 +91,13 @@ func (c *Compliance) projectIgnored(detectionResult detection.Result) bool {
 		}
 	}
 	return false
+}
+
+func (c *Compliance) sortMatchesByConfidenceThenLicence(matches []detection.LicenceMatch) {
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Confidence == matches[j].Confidence {
+			return matches[i].Licence < matches[j].Licence
+		}
+		return matches[i].Confidence > matches[j].Confidence
+	})
 }

--- a/pkg/compliance/compliance_test.go
+++ b/pkg/compliance/compliance_test.go
@@ -139,13 +139,14 @@ var _ = Describe("compliance check", func() {
 		Expect(results.Restricted[2].Project).To(Equal("B1"))
 	})
 
-	It("should order licences with the same confidence level alphabetically", func() {
+	It("should order licences with highest confidence first then alphabetically", func() {
 		// given
 		licenceDetector := newFakeLicenceDetector(
-			aProjectWithLicence("C1", map[string]float32{"MPL2.0": 0.9, "MPL2.0-no-copyleft": 0.9}),
-			aProjectWithLicence("C2", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9}),
-			aProjectWithLicence("R", map[string]float32{"MIT-other": 0.9, "MIT": 0.9}),
-			aProjectWithLicence("I", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9}),
+			aProjectWithLicence("C1", map[string]float32{"MPL2.0": 0.9, "MPL2.0-no-copyleft": 0.9, "Y": 0.92, "Z": 0.92}),
+			aProjectWithLicence("C2", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9, "Z": 0.89, "Y": 0.89}),
+			aProjectWithLicence("C3", map[string]float32{"Z": 0.91, "MIT-other": 0.9, "MIT": 0.9}),
+			aProjectWithLicence("R", map[string]float32{"Z": 0.89, "MIT-other": 0.9, "MIT": 0.9}),
+			aProjectWithLicence("I", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9, "Z": 0.91}),
 		)
 
 		c := New(&Config{RestrictedLicences: []string{"MIT"}, IgnoredProjects: []string{"I"}}, licenceDetector)
@@ -155,11 +156,12 @@ var _ = Describe("compliance check", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		Expect(results.Compliant).To(HaveLen(2))
-		Expect(results.Compliant).To(HaveProjectLicences("C1", "MPL2.0", "MPL2.0-no-copyleft"))
-		Expect(results.Compliant).To(HaveProjectLicences("C2", "MPL2.0", "MPL2.0-no-copyleft"))
-		Expect(results.Restricted).To(HaveProjectLicences("R", "MIT", "MIT-other"))
-		Expect(results.Ignored).To(HaveProjectLicences("I", "MPL2.0", "MPL2.0-no-copyleft"))
+		Expect(results.Compliant).To(HaveLen(3))
+		Expect(results.Compliant).To(HaveProjectLicences("C1", "Y", "Z", "MPL2.0", "MPL2.0-no-copyleft"))
+		Expect(results.Compliant).To(HaveProjectLicences("C2", "MPL2.0", "MPL2.0-no-copyleft", "Y", "Z"))
+		Expect(results.Compliant).To(HaveProjectLicences("C3", "Z", "MIT", "MIT-other"))
+		Expect(results.Restricted).To(HaveProjectLicences("R", "MIT", "MIT-other", "Z"))
+		Expect(results.Ignored).To(HaveProjectLicences("I", "Z", "MPL2.0", "MPL2.0-no-copyleft"))
 	})
 
 	Context("when a licence is overridden for a project", func() {

--- a/pkg/compliance/compliance_test.go
+++ b/pkg/compliance/compliance_test.go
@@ -139,6 +139,29 @@ var _ = Describe("compliance check", func() {
 		Expect(results.Restricted[2].Project).To(Equal("B1"))
 	})
 
+	It("should order licences with the same confidence level alphabetically", func() {
+		// given
+		licenceDetector := newFakeLicenceDetector(
+			aProjectWithLicence("C1", map[string]float32{"MPL2.0": 0.9, "MPL2.0-no-copyleft": 0.9}),
+			aProjectWithLicence("C2", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9}),
+			aProjectWithLicence("R", map[string]float32{"MIT-other": 0.9, "MIT": 0.9}),
+			aProjectWithLicence("I", map[string]float32{"MPL2.0-no-copyleft": 0.9, "MPL2.0": 0.9}),
+		)
+
+		c := New(&Config{RestrictedLicences: []string{"MIT"}, IgnoredProjects: []string{"I"}}, licenceDetector)
+
+		// when
+		results, err := c.Validate([]string{"A", "B"})
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results.Compliant).To(HaveLen(2))
+		Expect(results.Compliant).To(HaveProjectLicences("C1", "MPL2.0", "MPL2.0-no-copyleft"))
+		Expect(results.Compliant).To(HaveProjectLicences("C2", "MPL2.0", "MPL2.0-no-copyleft"))
+		Expect(results.Restricted).To(HaveProjectLicences("R", "MIT", "MIT-other"))
+		Expect(results.Ignored).To(HaveProjectLicences("I", "MPL2.0", "MPL2.0-no-copyleft"))
+	})
+
 	Context("when a licence is overridden for a project", func() {
 
 		It("should be used when identifying Restricted licences", func() {


### PR DESCRIPTION
Order licences match alphabetically to make the outcome deterministic 
when the go-licence-detector returns licence matches with the same level of confidence.
This is the case for MPL2.0 projects, where multiple licences match the
same licence texts and so have the same level of confidence.

Fixes #20